### PR TITLE
Upgrade package Swashbuckle.AspNetCore

### DIFF
--- a/Source/Boxed.AspNetCore.Swagger/Boxed.AspNetCore.Swagger.csproj
+++ b/Source/Boxed.AspNetCore.Swagger/Boxed.AspNetCore.Swagger.csproj
@@ -46,7 +46,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Condition="'$(OS)' == 'Windows_NT'" Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.0.0-beta-62909-01" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.0-beta007" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
An update in Swashbuckle.AspNetCore from 2.4.0 to 2.5.0 causes a System.MissingMethodException: Method not found: 'Void Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions.IncludeXmlComments(System.String)'.

https://github.com/Dotnet-Boxed/Framework/issues/19