### PR TITLE
Add null check to FilterDescriptorExtensions

### DIFF
--- a/Source/Boxed.AspNetCore.Swagger/FilterDescriptorExtensions.cs
+++ b/Source/Boxed.AspNetCore.Swagger/FilterDescriptorExtensions.cs
@@ -22,7 +22,7 @@ namespace Boxed.AspNetCore.Swagger
 
                 if (filterDescriptor.Filter is AuthorizeFilter authorizeFilter)
                 {
-                    if(authorizeFilter.Policy != null)
+                    if (authorizeFilter.Policy != null)
                     {
                         policyRequirements.AddRange(authorizeFilter.Policy.Requirements);
                     }

--- a/Source/Boxed.AspNetCore.Swagger/FilterDescriptorExtensions.cs
+++ b/Source/Boxed.AspNetCore.Swagger/FilterDescriptorExtensions.cs
@@ -22,7 +22,10 @@ namespace Boxed.AspNetCore.Swagger
 
                 if (filterDescriptor.Filter is AuthorizeFilter authorizeFilter)
                 {
-                    policyRequirements.AddRange(authorizeFilter.Policy.Requirements);
+                    if(authorizeFilter.Policy != null)
+                    {
+                        policyRequirements.AddRange(authorizeFilter.Policy.Requirements);
+                    }
                 }
             }
 


### PR DESCRIPTION
Not every `AuthorizeFilter` will have a policy; Some are dynamically created.

Ref https://github.com/Dotnet-Boxed/Framework/issues/24