### PR TITLE
Refactored tag helpers to use IUrlHelperFactory

### DIFF
--- a/Source/Boxed.AspNetCore.TagHelpers/HrefSubresourceIntegrityTagHelper.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/HrefSubresourceIntegrityTagHelper.cs
@@ -2,6 +2,8 @@ namespace Boxed.AspNetCore.TagHelpers
 {
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.AspNetCore.Mvc.Routing;
     using Microsoft.AspNetCore.Razor.TagHelpers;
     using Microsoft.Extensions.Caching.Distributed;
 
@@ -17,12 +19,14 @@ namespace Boxed.AspNetCore.TagHelpers
         /// </summary>
         /// <param name="distributedCache">The distributed cache.</param>
         /// <param name="hostingEnvironment">The hosting environment.</param>
-        /// <param name="urlHelper">The URL helper.</param>
+        /// <param name="actionContextAccessor">The MVC action context accessor.</param>
+        /// <param name="urlHelperFactory">The URL helper factory.</param>
         public HrefSubresourceIntegrityTagHelper(
             IDistributedCache distributedCache,
             IHostingEnvironment hostingEnvironment,
-            IUrlHelper urlHelper)
-            : base(distributedCache, hostingEnvironment, urlHelper)
+            IActionContextAccessor actionContextAccessor,
+            IUrlHelperFactory urlHelperFactory)
+            : base(distributedCache, hostingEnvironment, actionContextAccessor, urlHelperFactory)
         {
         }
 

--- a/Source/Boxed.AspNetCore.TagHelpers/HttpContextExtensions.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/HttpContextExtensions.cs
@@ -1,0 +1,36 @@
+namespace Boxed.AspNetCore.TagHelpers
+{
+    using System;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Http.Features;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.AspNetCore.Mvc.Routing;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// <see cref="HttpContext"/> extension methods.
+    /// </summary>
+    public static class HttpContextExtensions
+    {
+        /// <summary>
+        /// Gets UrlHelper instance using <see cref="IUrlHelperFactory"/> and <see cref="IActionContextAccessor"/>.
+        /// </summary>
+        /// <param name="httpContext">The HTTP context.</param>
+        /// <returns><see cref="UrlHelper"/> instance for current request.</returns>
+        public static IUrlHelper GetUrlHelper(this HttpContext httpContext)
+        {
+            var services = httpContext
+                           .Features
+                           .Get<IServiceProvidersFeature>()
+                           .RequestServices;
+            var actionContext = services
+                                .GetRequiredService<IActionContextAccessor>()
+                                .ActionContext;
+            var urlHelper = services
+                            .GetRequiredService<IUrlHelperFactory>()
+                            .GetUrlHelper(actionContext);
+            return urlHelper;
+        }
+    }
+}

--- a/Source/Boxed.AspNetCore.TagHelpers/OpenGraph/ObjectTypes/OpenGraphMetadata.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/OpenGraph/ObjectTypes/OpenGraphMetadata.cs
@@ -361,16 +361,7 @@ namespace Boxed.AspNetCore.TagHelpers.OpenGraph
         private string GetRequestUrl()
         {
             var httpContext = this.ViewContext.HttpContext;
-            var services = httpContext
-                .Features
-                .Get<IServiceProvidersFeature>()
-                .RequestServices;
-            var actionContext = services
-                .GetRequiredService<IActionContextAccessor>()
-                .ActionContext;
-            var urlHelper = services
-                .GetRequiredService<IUrlHelperFactory>()
-                .GetUrlHelper(actionContext);
+            var urlHelper = httpContext.GetUrlHelper();
             var request = httpContext.Request;
             return new Uri(new Uri(request.Scheme + "://" + request.Host.Value), urlHelper.Content(request.Path.Value)).ToString();
         }

--- a/Source/Boxed.AspNetCore.TagHelpers/OpenGraph/ObjectTypes/OpenGraphMetadata.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/OpenGraph/ObjectTypes/OpenGraphMetadata.cs
@@ -6,7 +6,9 @@ namespace Boxed.AspNetCore.TagHelpers.OpenGraph
     using System.Text;
     using Microsoft.AspNetCore.Http.Features;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
     using Microsoft.AspNetCore.Mvc.Rendering;
+    using Microsoft.AspNetCore.Mvc.Routing;
     using Microsoft.AspNetCore.Mvc.ViewFeatures;
     using Microsoft.AspNetCore.Razor.TagHelpers;
     using Microsoft.Extensions.DependencyInjection;
@@ -359,11 +361,16 @@ namespace Boxed.AspNetCore.TagHelpers.OpenGraph
         private string GetRequestUrl()
         {
             var httpContext = this.ViewContext.HttpContext;
-            var urlHelper = httpContext
+            var services = httpContext
                 .Features
                 .Get<IServiceProvidersFeature>()
-                .RequestServices
-                .GetRequiredService<IUrlHelper>();
+                .RequestServices;
+            var actionContext = services
+                .GetRequiredService<IActionContextAccessor>()
+                .ActionContext;
+            var urlHelper = services
+                .GetRequiredService<IUrlHelperFactory>()
+                .GetUrlHelper(actionContext);
             var request = httpContext.Request;
             return new Uri(new Uri(request.Scheme + "://" + request.Host.Value), urlHelper.Content(request.Path.Value)).ToString();
         }

--- a/Source/Boxed.AspNetCore.TagHelpers/OpenGraph/ObjectTypes/OpenGraphMetadata.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/OpenGraph/ObjectTypes/OpenGraphMetadata.cs
@@ -363,7 +363,8 @@ namespace Boxed.AspNetCore.TagHelpers.OpenGraph
             var httpContext = this.ViewContext.HttpContext;
             var urlHelper = httpContext.GetUrlHelper();
             var request = httpContext.Request;
-            return new Uri(new Uri(request.Scheme + "://" + request.Host.Value), urlHelper.Content(request.Path.Value)).ToString();
+            var baseUri = new Uri(string.Concat(request.Scheme, "://", request.Host.Value));
+            return new Uri(baseUri, urlHelper.Content(request.Path.Value)).ToString();
         }
     }
 }

--- a/Source/Boxed.AspNetCore.TagHelpers/SrcSubresourceIntegrityTagHelper.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/SrcSubresourceIntegrityTagHelper.cs
@@ -2,6 +2,8 @@ namespace Boxed.AspNetCore.TagHelpers
 {
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.AspNetCore.Mvc.Routing;
     using Microsoft.AspNetCore.Razor.TagHelpers;
     using Microsoft.Extensions.Caching.Distributed;
 
@@ -17,12 +19,14 @@ namespace Boxed.AspNetCore.TagHelpers
         /// </summary>
         /// <param name="distributedCache">The distributed cache.</param>
         /// <param name="hostingEnvironment">The hosting environment.</param>
-        /// <param name="urlHelper">The URL helper.</param>
+        /// <param name="actionContextAccessor">The MVC action context accessor.</param>
+        /// <param name="urlHelperFactory">The URL helper factory.</param>
         public SrcSubresourceIntegrityTagHelper(
             IDistributedCache distributedCache,
             IHostingEnvironment hostingEnvironment,
-            IUrlHelper urlHelper)
-            : base(distributedCache, hostingEnvironment, urlHelper)
+            IActionContextAccessor actionContextAccessor,
+            IUrlHelperFactory urlHelperFactory)
+            : base(distributedCache, hostingEnvironment, actionContextAccessor, urlHelperFactory)
         {
         }
 

--- a/Source/Boxed.AspNetCore.TagHelpers/SubresourceIntegrityTagHelper.cs
+++ b/Source/Boxed.AspNetCore.TagHelpers/SubresourceIntegrityTagHelper.cs
@@ -9,6 +9,8 @@ namespace Boxed.AspNetCore.TagHelpers
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Html;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.AspNetCore.Mvc.Routing;
     using Microsoft.AspNetCore.Razor.TagHelpers;
     using Microsoft.Extensions.Caching.Distributed;
 
@@ -36,15 +38,17 @@ namespace Boxed.AspNetCore.TagHelpers
         /// </summary>
         /// <param name="distributedCache">The distributed cache.</param>
         /// <param name="hostingEnvironment">The hosting environment.</param>
-        /// <param name="urlHelper">The URL helper.</param>
+        /// <param name="actionContextAccessor">The MVC action context accessor.</param>
+        /// <param name="urlHelperFactory">The URL helper factory.</param>
         public SubresourceIntegrityTagHelper(
             IDistributedCache distributedCache,
             IHostingEnvironment hostingEnvironment,
-            IUrlHelper urlHelper)
+            IActionContextAccessor actionContextAccessor,
+            IUrlHelperFactory urlHelperFactory)
         {
             this.distributedCache = distributedCache;
             this.hostingEnvironment = hostingEnvironment;
-            this.urlHelper = urlHelper;
+            this.urlHelper = urlHelperFactory.GetUrlHelper(actionContextAccessor.ActionContext);
         }
 
         /// <summary>

--- a/Tests/Boxed.AspNetCore.TagHelpers.Test/SubresourceIntegrityTagHelperTest.cs
+++ b/Tests/Boxed.AspNetCore.TagHelpers.Test/SubresourceIntegrityTagHelperTest.cs
@@ -8,6 +8,8 @@ namespace Boxed.AspNetCore.TagHelpers.Test
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Html;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Infrastructure;
+    using Microsoft.AspNetCore.Mvc.Routing;
     using Microsoft.AspNetCore.Razor.TagHelpers;
     using Microsoft.Extensions.Caching.Distributed;
     using Moq;
@@ -17,6 +19,8 @@ namespace Boxed.AspNetCore.TagHelpers.Test
     {
         private readonly Mock<IDistributedCache> distributedCacheMock;
         private readonly Mock<IHostingEnvironment> hostingEnvironmentMock;
+        private readonly Mock<IActionContextAccessor> actionContextAccessor;
+        private readonly Mock<IUrlHelperFactory> urlHelperFactoryMock;
         private readonly Mock<IUrlHelper> urlHelperMock;
         private readonly SubresourceIntegrityTagHelper tagHelper;
 
@@ -24,11 +28,18 @@ namespace Boxed.AspNetCore.TagHelpers.Test
         {
             this.distributedCacheMock = new Mock<IDistributedCache>(MockBehavior.Strict);
             this.hostingEnvironmentMock = new Mock<IHostingEnvironment>(MockBehavior.Strict);
+            this.actionContextAccessor = new Mock<IActionContextAccessor>(MockBehavior.Strict);
+            this.urlHelperFactoryMock = new Mock<IUrlHelperFactory>(MockBehavior.Strict);
             this.urlHelperMock = new Mock<IUrlHelper>(MockBehavior.Strict);
+
+            this.actionContextAccessor.SetupGet(x => x.ActionContext).Returns((ActionContext)null);
+            this.urlHelperFactoryMock.Setup(x => x.GetUrlHelper(this.actionContextAccessor.Object.ActionContext)).Returns(this.urlHelperMock.Object);
+
             this.tagHelper = new TestSubresourceIntegrityTagHelper(
                 this.distributedCacheMock.Object,
                 this.hostingEnvironmentMock.Object,
-                this.urlHelperMock.Object);
+                this.actionContextAccessor.Object,
+                this.urlHelperFactoryMock.Object);
         }
 
         [Fact]
@@ -131,8 +142,9 @@ namespace Boxed.AspNetCore.TagHelpers.Test
             public TestSubresourceIntegrityTagHelper(
                 IDistributedCache distributedCache,
                 IHostingEnvironment hostingEnvironment,
-                IUrlHelper urlHelper)
-                : base(distributedCache, hostingEnvironment, urlHelper)
+                IActionContextAccessor actionContextAccessor,
+                IUrlHelperFactory urlHelperFactory)
+                : base(distributedCache, hostingEnvironment, actionContextAccessor, urlHelperFactory)
             {
             }
 


### PR DESCRIPTION
So that you no longer need a hackish inject of IUrlHelper