### PR TITLE
Added options to HttpExceptionMiddleware to allow opt-in for including reason phrase in httpresponse

### DIFF
--- a/Source/Boxed.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/Source/Boxed.AspNetCore/ApplicationBuilderExtensions.cs
@@ -15,14 +15,24 @@ namespace Boxed.AspNetCore
         /// </summary>
         /// <param name="application">The application builder.</param>
         /// <returns>The same application builder.</returns>
-        public static IApplicationBuilder UseHttpException(this IApplicationBuilder application)
+        public static IApplicationBuilder UseHttpException(this IApplicationBuilder application) => UseHttpException(application, null);
+
+        /// <summary>
+        /// Allows the use of <see cref="HttpException"/> as an alternative method of returning an error result.
+        /// </summary>
+        /// <param name="application">The application builder.</param>
+        /// <param name="configureOptions">The middleware options.</param>
+        /// <returns>The same application builder.</returns>
+        public static IApplicationBuilder UseHttpException(this IApplicationBuilder application, Action<HttpExceptionMiddlewareOptions> configureOptions)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return application.UseMiddleware<HttpExceptionMiddleware>();
+            var options = new HttpExceptionMiddlewareOptions();
+            configureOptions?.Invoke(options);
+            return application.UseMiddleware<HttpExceptionMiddleware>(options);
         }
 
         /// <summary>

--- a/Source/Boxed.AspNetCore/Middleware/HttpExceptionMiddlewareOptions.cs
+++ b/Source/Boxed.AspNetCore/Middleware/HttpExceptionMiddlewareOptions.cs
@@ -1,0 +1,13 @@
+namespace Boxed.AspNetCore.Middleware
+{
+    /// <summary>
+    /// Options controlling <see cref="HttpExceptionMiddleware"/>.
+    /// </summary>
+    public class HttpExceptionMiddlewareOptions
+    {
+        /// <summary>
+        /// Property controlling if ReasonPhrase should be included in HttpResponseMessage.
+        /// </summary>
+        public bool IncludeReasonPhraseInResponse { get; set; } = false;
+    }
+}


### PR DESCRIPTION
I took the liberty of implementing options when adding the middleware to be able to opt-in to including ReasonPhrase in the HttpResponseMessage. Hope this looks good!