### PR TITLE
Add overloads to accept Action<BinderOptions>

### DIFF
--- a/Source/Boxed.AspNetCore/ServiceCollectionExtensions.cs
+++ b/Source/Boxed.AspNetCore/ServiceCollectionExtensions.cs
@@ -131,6 +131,35 @@
 
         /// <summary>
         /// Registers <see cref="IOptions{TOptions}"/> and <typeparamref name="TOptions"/> to the services container.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of the options.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="configureBinder">Used to configure the binder options.</param>
+        /// <returns>The same services collection.</returns>
+        public static IServiceCollection ConfigureSingleton<TOptions>(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            Action<BinderOptions> configureBinder)
+            where TOptions : class, new()
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            return services
+                .Configure<TOptions>(configuration, configureBinder)
+                .AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);
+        }
+
+        /// <summary>
+        /// Registers <see cref="IOptions{TOptions}"/> and <typeparamref name="TOptions"/> to the services container.
         /// Also runs data annotation validation.
         /// </summary>
         /// <typeparam name="TOptions">The type of the options.</typeparam>
@@ -155,6 +184,38 @@
             services
                 .AddOptions<TOptions>()
                 .Bind(configuration)
+                .ValidateDataAnnotations();
+            return services.AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);
+        }
+
+        /// <summary>
+        /// Registers <see cref="IOptions{TOptions}"/> and <typeparamref name="TOptions"/> to the services container.
+        /// Also runs data annotation validation.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of the options.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="configureBinder">Used to configure the binder options.</param>
+        /// <returns>The same services collection.</returns>
+        public static IServiceCollection ConfigureAndValidateSingleton<TOptions>(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            Action<BinderOptions> configureBinder)
+            where TOptions : class, new()
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            services
+                .AddOptions<TOptions>()
+                .Bind(configuration, configureBinder)
                 .ValidateDataAnnotations();
             return services.AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);
         }
@@ -192,6 +253,46 @@
             services
                 .AddOptions<TOptions>()
                 .Bind(configuration)
+                .ValidateDataAnnotations()
+                .Validate(validation);
+            return services.AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);
+        }
+
+        /// <summary>
+        /// Registers <see cref="IOptions{TOptions}"/> and <typeparamref name="TOptions"/> to the services container.
+        /// Also runs data annotation validation and custom validation using the default failure message.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of the options.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="configureBinder">Used to configure the binder options.</param>
+        /// <returns>The same services collection.</returns>
+        public static IServiceCollection ConfigureAndValidateSingleton<TOptions>(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            Func<TOptions, bool> validation,
+            Action<BinderOptions> configureBinder)
+            where TOptions : class, new()
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (validation is null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            services
+                .AddOptions<TOptions>()
+                .Bind(configuration, configureBinder)
                 .ValidateDataAnnotations()
                 .Validate(validation);
             return services.AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);
@@ -237,6 +338,53 @@
             services
                 .AddOptions<TOptions>()
                 .Bind(configuration)
+                .ValidateDataAnnotations()
+                .Validate(validation, failureMessage);
+            return services.AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);
+        }
+
+        /// <summary>
+        /// Registers <see cref="IOptions{TOptions}"/> and <typeparamref name="TOptions"/> to the services container.
+        /// Also runs data annotation validation and custom validation.
+        /// </summary>
+        /// <typeparam name="TOptions">The type of the options.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="validation">The validation function.</param>
+        /// <param name="failureMessage">The failure message to use when validation fails.</param>
+        /// <param name="configureBinder">Used to configure the binder options.</param>
+        /// <returns>The same services collection.</returns>
+        public static IServiceCollection ConfigureAndValidateSingleton<TOptions>(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            Func<TOptions, bool> validation,
+            string failureMessage,
+            Action<BinderOptions> configureBinder)
+            where TOptions : class, new()
+        {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (validation is null)
+            {
+                throw new ArgumentNullException(nameof(validation));
+            }
+
+            if (failureMessage is null)
+            {
+                throw new ArgumentNullException(nameof(failureMessage));
+            }
+
+            services
+                .AddOptions<TOptions>()
+                .Bind(configuration, configureBinder)
                 .ValidateDataAnnotations()
                 .Validate(validation, failureMessage);
             return services.AddSingleton(x => x.GetRequiredService<IOptions<TOptions>>().Value);


### PR DESCRIPTION
As of Core 2.1 `.Bind` and `.Configure` can now take an Action<BinderOptions>. The main importance of this new action is to allow setting `BindNonPublicProperties` which lets you make the props for your options classes `private set;`.
https://github.com/aspnet/Configuration/issues/394

https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.binderoptions.bindnonpublicproperties?view=dotnet-plat-ext-3.1#Microsoft_Extensions_Configuration_BinderOptions_BindNonPublicProperties

Closes #208
