### PR TITLE
Stop passing --urls to dotnet run

### DIFF
--- a/Source/Boxed.DotnetNewTest/Project.cs
+++ b/Source/Boxed.DotnetNewTest/Project.cs
@@ -1,5 +1,7 @@
 namespace Boxed.DotnetNewTest
 {
+    using System;
+
     /// <summary>
     /// A project created from a project template.
     /// </summary>
@@ -11,14 +13,20 @@ namespace Boxed.DotnetNewTest
         /// <param name="name">The name of the project.</param>
         /// <param name="directoryPath">The directory path to the project.</param>
         /// <param name="publishDirectoryPath">The publish directory path.</param>
+        /// <param name="httpsPort">The HTTPS port.</param>
+        /// <param name="httpPort">The HTTP port.</param>
         public Project(
             string name,
             string directoryPath,
-            string publishDirectoryPath)
+            string publishDirectoryPath,
+            int httpsPort,
+            int httpPort)
         {
             this.Name = name;
             this.DirectoryPath = directoryPath;
             this.PublishDirectoryPath = publishDirectoryPath;
+            this.HttpsPort = httpsPort;
+            this.HttpPort = httpPort;
         }
 
         /// <summary>
@@ -35,5 +43,25 @@ namespace Boxed.DotnetNewTest
         /// Gets the publish directory path to the project.
         /// </summary>
         public string PublishDirectoryPath { get; }
+
+        /// <summary>
+        /// Gets the HTTP port.
+        /// </summary>
+        public int HttpPort { get; }
+
+        /// <summary>
+        /// Gets the HTTPS port.
+        /// </summary>
+        public int HttpsPort { get; }
+
+        /// <summary>
+        /// Gets the HTTP URL.
+        /// </summary>
+        public Uri HttpUrl => new Uri($"http://localhost:{this.HttpPort}");
+
+        /// <summary>
+        /// Gets the HTTPS URL.
+        /// </summary>
+        public Uri HttpsUrl => new Uri($"https://localhost:{this.HttpsPort}");
     }
 }

--- a/Source/Boxed.DotnetNewTest/ProjectExtensions.cs
+++ b/Source/Boxed.DotnetNewTest/ProjectExtensions.cs
@@ -249,15 +249,12 @@ namespace Boxed.DotnetNewTest
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var httpPort = PortHelper.GetFreeTcpPort();
-            var httpUrl = new Uri($"http://localhost:{httpPort}");
-
             var httpClientHandler = new HttpClientHandler()
             {
                 AllowAutoRedirect = false,
                 ServerCertificateCustomValidationCallback = validateCertificate ?? DefaultValidateCertificate,
             };
-            var httpClient = new HttpClient(httpClientHandler) { BaseAddress = httpUrl };
+            var httpClient = new HttpClient(httpClientHandler) { BaseAddress = project.HttpUrl };
 
             var projectFilePath = Path.Combine(project.DirectoryPath, projectRelativeDirectoryPath);
             var dotnetRun = await DotnetRunInternalAsync(
@@ -267,8 +264,7 @@ namespace Boxed.DotnetNewTest
                     projectFilePath,
                     noRestore,
                     timeout,
-                    showShellWindow,
-                    httpUrl)
+                    showShellWindow)
                 .ConfigureAwait(false);
 
             try
@@ -320,18 +316,13 @@ namespace Boxed.DotnetNewTest
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var httpPort = PortHelper.GetFreeTcpPort();
-            var httpsPort = PortHelper.GetFreeTcpPort();
-            var httpUrl = new Uri($"http://localhost:{httpPort}");
-            var httpsUrl = new Uri($"https://localhost:{httpsPort}");
-
             var httpClientHandler = new HttpClientHandler()
             {
                 AllowAutoRedirect = false,
                 ServerCertificateCustomValidationCallback = validateCertificate ?? DefaultValidateCertificate,
             };
-            var httpClient = new HttpClient(httpClientHandler) { BaseAddress = httpUrl };
-            var httpsClient = new HttpClient(httpClientHandler) { BaseAddress = httpsUrl };
+            var httpClient = new HttpClient(httpClientHandler) { BaseAddress = project.HttpUrl };
+            var httpsClient = new HttpClient(httpClientHandler) { BaseAddress = project.HttpsUrl };
 
             var projectFilePath = Path.Combine(project.DirectoryPath, projectRelativeDirectoryPath);
             var dotnetRun = await DotnetRunInternalAsync(
@@ -341,9 +332,7 @@ namespace Boxed.DotnetNewTest
                     projectFilePath,
                     noRestore,
                     timeout,
-                    showShellWindow,
-                    httpUrl,
-                    httpsUrl)
+                    showShellWindow)
                 .ConfigureAwait(false);
 
             try
@@ -426,18 +415,16 @@ namespace Boxed.DotnetNewTest
             string directoryPath,
             bool? noRestore,
             TimeSpan? timeout,
-            bool showShellWindow,
-            params Uri[] urls)
+            bool showShellWindow)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope. Object disposed below.
             var cancellationTokenSource = new CancellationTokenSource();
 #pragma warning restore CA2000 // Dispose objects before losing scope. Object disposed below.
             var noRestoreArgument = noRestore is null ? null : "--no-restore";
-            var urlsParameter = string.Join(";", urls.Select(x => x.ToString()));
             var task = AssertStartAsync(
                 directoryPath,
                 "dotnet",
-                $"run {noRestoreArgument} --urls {urlsParameter}",
+                $"run {noRestoreArgument}",
                 showShellWindow,
                 cancellationTokenSource.Token);
 

--- a/Source/Boxed.DotnetNewTest/TempDirectoryExtensions.cs
+++ b/Source/Boxed.DotnetNewTest/TempDirectoryExtensions.cs
@@ -42,11 +42,14 @@ namespace Boxed.DotnetNewTest
                 stringBuilder.Append($" --name \"{name}\"");
             }
 
+            var httpsPort = PortHelper.GetFreeTcpPort();
+            var httpPort = PortHelper.GetFreeTcpPort();
+
             if (arguments is not null)
             {
                 foreach (var argument in arguments)
                 {
-                    stringBuilder.Append($" --{argument.Key} \"{argument.Value}\"");
+                    stringBuilder.Append($" --{argument.Key} \"{Replace(argument.Value, httpsPort, httpPort)}\"");
                 }
             }
 
@@ -64,7 +67,12 @@ namespace Boxed.DotnetNewTest
 
             var projectDirectoryPath = name == null ? tempDirectory.DirectoryPath : Path.Combine(tempDirectory.DirectoryPath, name);
             var publishDirectoryPath = Path.Combine(projectDirectoryPath, "Publish");
-            return new Project(name, projectDirectoryPath, publishDirectoryPath);
+            return new Project(name, projectDirectoryPath, publishDirectoryPath, httpsPort, httpPort);
         }
+
+        private static string Replace(string value, int httpsPort, int httpPort) =>
+            value
+                .Replace("{HTTPS_PORT}", httpsPort.ToString())
+                .Replace("{HTTP_PORT}", httpPort.ToString());
     }
 }


### PR DESCRIPTION
Switch from passing `--urls` argument to `dotnet run` which no longer works (probably due to Kestrel configuring itself from `IConfiguration` differently somehow) to passing the HTTP and HTTPS port to the `dotnet new` command instead which creates the project from the template with the right ports in the first place.